### PR TITLE
Add extra support for Legacy Fabric

### DIFF
--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/Constants.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/Constants.kt
@@ -26,6 +26,8 @@ object Constants {
 
     const val FABRIC_PROVIDER = "fabric"
 
+    const val LEGACY_FABRIC_PROVIDER = "legacyFabric"
+
     const val QUILT_PROVIDER = "quilt"
 
     const val FORGE_PROVIDER = "forge"

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/fabric/FabricApiExtension.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/fabric/FabricApiExtension.kt
@@ -1,8 +1,6 @@
 package xyz.wagyourtail.unimined.api.fabric
 
 import org.gradle.api.Project
-import java.net.URL
-import javax.xml.parsers.DocumentBuilderFactory
 
 /**
  * helper class for getting fabric api parts.
@@ -18,38 +16,18 @@ import javax.xml.parsers.DocumentBuilderFactory
  * }
  */
 @Suppress("unused")
-open class FabricApiExtension {
+open class FabricApiExtension : FabricLikeApiExtension("fabric-api") {
     companion object {
         fun apply(target: Project) {
             target.extensions.create("fabricApi", FabricApiExtension::class.java)
         }
     }
 
-    fun module(name: String, version: String): String {
-        val url = URL("https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api/$version/fabric-api-$version.pom")
-        url.openStream().use {
-            val dbf = DocumentBuilderFactory.newInstance()
-            val db = dbf.newDocumentBuilder()
-            val doc = db.parse(it)
-            val elements = doc.getElementsByTagName("dependency")
-            for (i in 0 until elements.length) {
-                val element = elements.item(i)
-                var correct = false
-                var vers: String? = null
-                for (j in 0 until element.childNodes.length) {
-                    val child = element.childNodes.item(j)
-                    if (child.nodeName == "artifactId" && child.textContent == name) {
-                        correct = true
-                    }
-                    if (child.nodeName == "version") {
-                        vers = child.textContent
-                    }
-                }
-                if (correct) {
-                    return "net.fabricmc.fabric-api:$name:$vers"
-                }
-            }
-        }
-        throw IllegalStateException("Could not find module $name in fabric-api $version")
+    override fun getUrl(version: String): String {
+        return "https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api/$version/fabric-api-$version.pom"
+    }
+
+    override fun getArtifactName(moduleName: String, version: String?): String {
+        return "net.fabricmc.fabric-api:$moduleName:$version"
     }
 }

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/fabric/FabricLikeApiExtension.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/fabric/FabricLikeApiExtension.kt
@@ -1,0 +1,37 @@
+package xyz.wagyourtail.unimined.api.fabric
+
+import java.net.URL
+import javax.xml.parsers.DocumentBuilderFactory
+
+abstract class FabricLikeApiExtension(val name: String) {
+    fun module(moduleName: String, version: String): String {
+        val url = URL(getUrl(version))
+        url.openStream().use {
+            val dbf = DocumentBuilderFactory.newInstance()
+            val db = dbf.newDocumentBuilder()
+            val doc = db.parse(it)
+            val elements = doc.getElementsByTagName("dependency")
+            for (i in 0 until elements.length) {
+                val element = elements.item(i)
+                var correct = false
+                var vers: String? = null
+                for (j in 0 until element.childNodes.length) {
+                    val child = element.childNodes.item(j)
+                    if (child.nodeName == "artifactId" && child.textContent == moduleName) {
+                        correct = true
+                    }
+                    if (child.nodeName == "version") {
+                        vers = child.textContent
+                    }
+                }
+                if (correct) {
+                    return getArtifactName(moduleName, vers)
+                }
+            }
+        }
+        throw IllegalStateException("Could not find module $moduleName in $name $version")
+    }
+
+    abstract fun getUrl(version: String): String
+    abstract fun getArtifactName(moduleName: String, version: String?): String
+}

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/fabric/LegacyFabricApiExtension.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/fabric/LegacyFabricApiExtension.kt
@@ -1,0 +1,55 @@
+package xyz.wagyourtail.unimined.api.fabric
+
+import org.gradle.api.Project
+import java.net.URL
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * helper class for getting legacy fabric api parts.
+ *
+ * @since 0.4.2
+ *
+ * usage:
+ * ```groovy
+ * dependencies {
+ *    ...
+ *    // fabric api part
+ *    modImplementation legacyFabricApi.module("fabric-api-base", "0.67.1+1.19.2")
+ * }
+ */
+@Suppress("unused")
+open class LegacyFabricApiExtension {
+    companion object {
+        fun apply(target: Project) {
+            target.extensions.create("legacyFabricApi", LegacyFabricApiExtension::class.java)
+        }
+    }
+
+    fun module(name: String, version: String): String {
+        val url = URL("https://repo.legacyfabric.net/repository/legacyfabric/net/legacyfabric/legacy-fabric-api/legacy-fabric-api/$version/legacy-fabric-api-$version.pom")
+        url.openStream().use {
+            val dbf = DocumentBuilderFactory.newInstance()
+            val db = dbf.newDocumentBuilder()
+            val doc = db.parse(it)
+            val elements = doc.getElementsByTagName("dependency")
+            for (i in 0 until elements.length) {
+                val element = elements.item(i)
+                var correct = false
+                var vers: String? = null
+                for (j in 0 until element.childNodes.length) {
+                    val child = element.childNodes.item(j)
+                    if (child.nodeName == "artifactId" && child.textContent == name) {
+                        correct = true
+                    }
+                    if (child.nodeName == "version") {
+                        vers = child.textContent
+                    }
+                }
+                if (correct) {
+                    return "net.legacyfabric.legacy-fabric-api:$name:$vers"
+                }
+            }
+        }
+        throw IllegalStateException("Could not find module $name in legacy-fabric-api $version")
+    }
+}

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/fabric/LegacyFabricApiExtension.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/fabric/LegacyFabricApiExtension.kt
@@ -1,8 +1,6 @@
 package xyz.wagyourtail.unimined.api.fabric
 
 import org.gradle.api.Project
-import java.net.URL
-import javax.xml.parsers.DocumentBuilderFactory
 
 /**
  * helper class for getting legacy fabric api parts.
@@ -13,43 +11,23 @@ import javax.xml.parsers.DocumentBuilderFactory
  * ```groovy
  * dependencies {
  *    ...
- *    // fabric api part
+ *    // legacy fabric api part
  *    modImplementation legacyFabricApi.module("fabric-api-base", "0.67.1+1.19.2")
  * }
  */
 @Suppress("unused")
-open class LegacyFabricApiExtension {
+open class LegacyFabricApiExtension : FabricLikeApiExtension("legacy-fabric-api") {
     companion object {
         fun apply(target: Project) {
             target.extensions.create("legacyFabricApi", LegacyFabricApiExtension::class.java)
         }
     }
 
-    fun module(name: String, version: String): String {
-        val url = URL("https://repo.legacyfabric.net/repository/legacyfabric/net/legacyfabric/legacy-fabric-api/legacy-fabric-api/$version/legacy-fabric-api-$version.pom")
-        url.openStream().use {
-            val dbf = DocumentBuilderFactory.newInstance()
-            val db = dbf.newDocumentBuilder()
-            val doc = db.parse(it)
-            val elements = doc.getElementsByTagName("dependency")
-            for (i in 0 until elements.length) {
-                val element = elements.item(i)
-                var correct = false
-                var vers: String? = null
-                for (j in 0 until element.childNodes.length) {
-                    val child = element.childNodes.item(j)
-                    if (child.nodeName == "artifactId" && child.textContent == name) {
-                        correct = true
-                    }
-                    if (child.nodeName == "version") {
-                        vers = child.textContent
-                    }
-                }
-                if (correct) {
-                    return "net.legacyfabric.legacy-fabric-api:$name:$vers"
-                }
-            }
-        }
-        throw IllegalStateException("Could not find module $name in legacy-fabric-api $version")
+    override fun getUrl(version: String): String {
+        return "https://repo.legacyfabric.net/repository/legacyfabric/net/legacyfabric/legacy-fabric-api/legacy-fabric-api/$version/legacy-fabric-api-$version.pom"
+    }
+
+    override fun getArtifactName(moduleName: String, version: String?): String {
+        return "net.legacyfabric.legacy-fabric-api:$moduleName:$version"
     }
 }

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftProvider.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftProvider.kt
@@ -165,6 +165,40 @@ abstract class MinecraftProvider<T: MinecraftRemapper, U : MinecraftPatcher>(val
         fabric {}
     }
 
+
+    /**
+     * enables the fabric patcher.
+     * @param action the action to configure the patcher.
+     * @since 0.1.0
+     */
+    abstract fun legacyFabric(action: (FabricLikePatcher) -> Unit)
+
+    /**
+     * enables the fabric patcher.
+     * @param action the action to perform on the patcher.
+     * @since 0.1.0
+     */
+    fun legacyFabric(
+        @DelegatesTo(
+            value = FabricLikePatcher::class,
+            strategy = Closure.DELEGATE_FIRST
+        ) action: Closure<*>
+    ) {
+        legacyFabric {
+            action.delegate = it
+            action.resolveStrategy = Closure.DELEGATE_FIRST
+            action.call()
+        }
+    }
+
+    /**
+     * enables the fabric patcher.
+     * @since 0.1.0
+     */
+    fun legacyFabric() {
+        legacyFabric {}
+    }
+
     /**
      * enables the quilt patcher.
      * @param action the action to configure the patcher.

--- a/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftProvider.kt
+++ b/src/api/kotlin/xyz/wagyourtail/unimined/api/minecraft/MinecraftProvider.kt
@@ -165,18 +165,17 @@ abstract class MinecraftProvider<T: MinecraftRemapper, U : MinecraftPatcher>(val
         fabric {}
     }
 
-
     /**
-     * enables the fabric patcher.
-     * @param action the action to configure the patcher.
-     * @since 0.1.0
+     * enables the fabric patcher with additional tweaks for LegacyFabric.
+     * @param action the action to perform on the patcher.
+     * @since 0.4.2
      */
     abstract fun legacyFabric(action: (FabricLikePatcher) -> Unit)
 
     /**
-     * enables the fabric patcher.
+     * enables the fabric patcher with additional tweaks for LegacyFabric.
      * @param action the action to perform on the patcher.
-     * @since 0.1.0
+     * @since 0.4.2
      */
     fun legacyFabric(
         @DelegatesTo(
@@ -192,8 +191,8 @@ abstract class MinecraftProvider<T: MinecraftRemapper, U : MinecraftPatcher>(val
     }
 
     /**
-     * enables the fabric patcher.
-     * @since 0.1.0
+     * enables the fabric patcher with additional tweaks for LegacyFabric.
+     * @since 0.4.2
      */
     fun legacyFabric() {
         legacyFabric {}

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/MinecraftProviderImpl.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/MinecraftProviderImpl.kt
@@ -29,9 +29,7 @@ import xyz.wagyourtail.unimined.launch.LauncherProvierImpl
 import xyz.wagyourtail.unimined.minecraft.patch.AbstractMinecraftTransformer
 import xyz.wagyourtail.unimined.minecraft.patch.MinecraftJar
 import xyz.wagyourtail.unimined.minecraft.patch.NoTransformMinecraftTransformer
-import xyz.wagyourtail.unimined.minecraft.patch.fabric.FabricLikeMinecraftTransformer
-import xyz.wagyourtail.unimined.minecraft.patch.fabric.FabricMinecraftTransformer
-import xyz.wagyourtail.unimined.minecraft.patch.fabric.QuiltMinecraftTransformer
+import xyz.wagyourtail.unimined.minecraft.patch.fabric.*
 import xyz.wagyourtail.unimined.minecraft.patch.forge.ForgeMinecraftTransformer
 import xyz.wagyourtail.unimined.minecraft.patch.jarmod.JarModMinecraftTransformer
 import xyz.wagyourtail.unimined.minecraft.patch.remap.MinecraftRemapperImpl
@@ -143,7 +141,12 @@ abstract class MinecraftProviderImpl(
     }
 
     override fun fabric(action: (FabricLikePatcher) -> Unit) {
-        mcPatcher = FabricMinecraftTransformer(project, this)
+        mcPatcher = OfficialFabricMinecraftTransformer(project, this)
+        action(mcPatcher as FabricLikeMinecraftTransformer)
+    }
+
+    override fun legacyFabric(action: (FabricLikePatcher) -> Unit) {
+        mcPatcher = LegacyFabricMinecraftTransformer(project, this)
         action(mcPatcher as FabricLikeMinecraftTransformer)
     }
 

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/patch/fabric/FabricMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/patch/fabric/FabricMinecraftTransformer.kt
@@ -6,18 +6,20 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import xyz.wagyourtail.unimined.api.Constants
 import xyz.wagyourtail.unimined.api.fabric.FabricApiExtension
+import xyz.wagyourtail.unimined.api.fabric.LegacyFabricApiExtension
 import xyz.wagyourtail.unimined.api.launch.LaunchConfig
 import xyz.wagyourtail.unimined.api.minecraft.EnvType
 import xyz.wagyourtail.unimined.minecraft.MinecraftProviderImpl
 import java.net.URI
 
-class FabricMinecraftTransformer(
+open class FabricMinecraftTransformer(
     project: Project,
-    provider: MinecraftProviderImpl
+    provider: MinecraftProviderImpl,
+    providerName: String
 ) : FabricLikeMinecraftTransformer(
     project,
     provider,
-    Constants.FABRIC_PROVIDER,
+    providerName,
     "fabric.mod.json",
     "accessWidener"
 ) {
@@ -26,6 +28,10 @@ class FabricMinecraftTransformer(
     override val ENV_TYPE: String = "Lnet/fabricmc/api/EnvType;"
 
     init {
+        setupApiExtension()
+    }
+
+    open fun setupApiExtension() {
         FabricApiExtension.apply(project)
     }
 

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/patch/fabric/LegacyFabricMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/patch/fabric/LegacyFabricMinecraftTransformer.kt
@@ -1,0 +1,24 @@
+package xyz.wagyourtail.unimined.minecraft.patch.fabric
+
+import org.gradle.api.Project
+import xyz.wagyourtail.unimined.api.Constants
+import xyz.wagyourtail.unimined.api.fabric.LegacyFabricApiExtension
+import xyz.wagyourtail.unimined.minecraft.MinecraftProviderImpl
+import java.net.URI
+
+class LegacyFabricMinecraftTransformer(
+    project: Project,
+    provider: MinecraftProviderImpl
+) : FabricMinecraftTransformer(project, provider, Constants.LEGACY_FABRIC_PROVIDER) {
+    override fun setupApiExtension() {
+        LegacyFabricApiExtension.apply(project)
+    }
+
+    override fun addMavens() {
+        super.addMavens()
+
+        project.repositories.maven {
+            it.url = URI.create("https://repo.legacyfabric.net/repository/legacyfabric")
+        }
+    }
+}

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/patch/fabric/OfficialFabricMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/patch/fabric/OfficialFabricMinecraftTransformer.kt
@@ -1,0 +1,11 @@
+package xyz.wagyourtail.unimined.minecraft.patch.fabric
+
+import org.gradle.api.Project
+import xyz.wagyourtail.unimined.api.Constants
+import xyz.wagyourtail.unimined.minecraft.MinecraftProviderImpl
+
+class OfficialFabricMinecraftTransformer(
+    project: Project,
+    provider: MinecraftProviderImpl
+) : FabricMinecraftTransformer(project, provider, Constants.FABRIC_PROVIDER) {
+}


### PR DESCRIPTION
Legacy Fabric is a fabric fork using official loader with our intermediary, mappings and api.
It supports Minecraft versions ranging from 1.3.0 to 1.13.2.