### PR TITLE
Fix Fabric runClient crash on Windows

### DIFF
--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
@@ -255,9 +255,9 @@ abstract class FabricLikeMinecraftTransformer(
 
     protected fun getIntermediaryClassPath(envType: EnvType): String {
         val remapClasspath = project.unimined.getLocalCache().resolve("remapClasspath.txt")
-        val s = provider.mcLibraries.files.joinToString(":") + ":" +
-                project.unimined.modProvider.modRemapper.preTransform(envType).joinToString(":") + ":" +
-                provider.getMinecraftWithMapping(envType, prodNamespace, prodNamespace)
+        val s = arrayOf(provider.mcLibraries.files.joinToString(File.pathSeparator),
+            project.unimined.modProvider.modRemapper.preTransform(envType).joinToString(File.pathSeparator),
+            provider.getMinecraftWithMapping(envType, prodNamespace, prodNamespace)).joinToString(File.pathSeparator)
         remapClasspath.writeText(s, options = arrayOf(StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING))
         return remapClasspath.absolutePathString()
     }

--- a/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
+++ b/src/minecraft/kotlin/xyz/wagyourtail/unimined/minecraft/patch/fabric/FabricLikeMinecraftTransformer.kt
@@ -255,9 +255,12 @@ abstract class FabricLikeMinecraftTransformer(
 
     protected fun getIntermediaryClassPath(envType: EnvType): String {
         val remapClasspath = project.unimined.getLocalCache().resolve("remapClasspath.txt")
-        val s = arrayOf(provider.mcLibraries.files.joinToString(File.pathSeparator),
+        val s = arrayOf(
+            provider.mcLibraries.files.joinToString(File.pathSeparator),
             project.unimined.modProvider.modRemapper.preTransform(envType).joinToString(File.pathSeparator),
-            provider.getMinecraftWithMapping(envType, prodNamespace, prodNamespace)).joinToString(File.pathSeparator)
+            provider.getMinecraftWithMapping(envType, prodNamespace, prodNamespace).toString()
+        ).filter { it.isNotEmpty() }.joinToString(File.pathSeparator)
+
         remapClasspath.writeText(s, options = arrayOf(StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING))
         return remapClasspath.absolutePathString()
     }


### PR DESCRIPTION
If put a mod into your mods folder and then run the Fabric client it will crash [here](https://github.com/FabricMC/fabric-loader/blob/09646a90ebe2a5db717a2fd2b36484bfa2dbc050/src/main/java/net/fabricmc/loader/impl/discovery/RuntimeModRemapper.java#L204) on Windows.
That is because the paths in `remapClasspath.txt` are separated by `:` characters which are not valid on Windows.
I also noticed that `project.unimined.modProvider.modRemapper.preTransform(envType).joinToString(File.pathSeparator)` might produce an empty String, so I added the `.filter { it.isNotEmpty() }`.

